### PR TITLE
pxssh python module has moved to pexpect.pxssh

### DIFF
--- a/updog/netdevice.py
+++ b/updog/netdevice.py
@@ -6,7 +6,7 @@ import re
 import os
 import ConfigParser
 import pexpect
-import pxssh
+from pexpect import pxssh
 import netvendor
 
 class NetworkDevice(object):


### PR DESCRIPTION
if you care you could

```
try:
    from pexpect import pxssh
except ImportError:
    import pxssh
```
